### PR TITLE
Added nil check in Lookup method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 examples/tool/tool
 examples/daemon/daemon
 go-extpoints
+testextpoints/extpoints.go

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+GO ?= go
+TESTPKG := testextpoints
+TESTTARGET := ./...
+
+test:
+	$(GO) run main.go template.go $(TESTPKG); $(GO) test -v $(TESTTARGET)

--- a/template.go
+++ b/template.go
@@ -128,6 +128,9 @@ func (ep *{{.Type}}) Register(component {{.Name}}, name string) bool {
 
 func (ep *{{.Type}}) Lookup(name string) ({{.Name}}, bool) {
 	ext, ok := ep.lookup(name)
+	if ext == nil {
+		return nil, ok
+	}
 	return ext.({{.Name}}), ok
 }
 

--- a/template.go
+++ b/template.go
@@ -128,7 +128,7 @@ func (ep *{{.Type}}) Register(component {{.Name}}, name string) bool {
 
 func (ep *{{.Type}}) Lookup(name string) ({{.Name}}, bool) {
 	ext, ok := ep.lookup(name)
-	if ext == nil {
+	if !ok {
 		return nil, ok
 	}
 	return ext.({{.Name}}), ok

--- a/testextpoints/plugins.go
+++ b/testextpoints/plugins.go
@@ -1,0 +1,14 @@
+package testextpoints
+
+type Dummy interface {
+	Do()
+}
+
+func init() {
+	dummies.Register(new(dummyA), "")
+}
+
+type dummyA struct{}
+
+func (da *dummyA) Do() {
+}

--- a/testextpoints/template_test.go
+++ b/testextpoints/template_test.go
@@ -1,0 +1,20 @@
+package testextpoints
+
+import "testing"
+
+var dummies = Dummies
+
+func TestLookupSuccess(t *testing.T) {
+	lookup(t, "dummyA", true)
+}
+
+func TestLookupFail(t *testing.T) {
+	lookup(t, "dummyNotExist", false)
+}
+
+func lookup(t *testing.T, name string, expectedOk bool) {
+	_, ok := dummies.Lookup(name)
+	if ok != expectedOk {
+		t.Errorf("Expected 'ok' flag %v, but got %v\n", expectedOk, ok)
+	}
+}


### PR DESCRIPTION
Hi progrium.

When "Lookup" method is called by __non-exist__ name, I expected it return `nil, false`.

My test result:
```
% cd $GOPATH/github.com/goldeneggg/go-extpoints
% make
go run main.go template.go testextpoints; go test -v ./...
extpoints: Processing file testextpoints/plugins.go
extpoints: Found interfaces: []string{"Dummy"}
extpoints: Processing file testextpoints/template_test.go
extpoints: Found interfaces: []string(nil)
extpoints: Writing file testextpoints/extpoints.go
?       github.com/goldeneggg/go-extpoints      [no test files]
?       github.com/goldeneggg/go-extpoints/examples/extensions/tool-example     [no test files]
?       github.com/goldeneggg/go-extpoints/examples/tool        [no test files]
?       github.com/goldeneggg/go-extpoints/examples/tool/extpoints      [no test files]
?       github.com/goldeneggg/go-extpoints/examples/tool/types  [no test files]
=== RUN TestLookupSuccess
--- PASS: TestLookupSuccess (0.00s)
=== RUN TestLookupFail
--- PASS: TestLookupFail (0.00s)
PASS
ok      github.com/goldeneggg/go-extpoints/testextpoints        0.010s
```

(Sorry about my poor English.)