### PR TITLE
Fix readme to say use `go get` instead of `go install` to get (and install) go-extpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It generates package extension point singletons from extension types you define.
 
 ## Getting the tool
 
-	$ go install github.com/progrium/go-extpoints
+	$ go get github.com/progrium/go-extpoints
 
 ## Concepts
 


### PR DESCRIPTION
Note, `go get` will fetch and install, whereas `go install` will just install, but if it is not already in the go workspace, will report an error, e.g.

```
$ go install github.com/progrium/go-extpoints
can't load package: package github.com/progrium/go-extpoints: cannot find package "github.com/progrium/go-extpoints" in any of:
    /usr/local/Cellar/go/1.5.1/libexec/src/github.com/progrium/go-extpoints (from $GOROOT)
    /Users/pmoore/go/src/github.com/progrium/go-extpoints (from $GOPATH)
```

With `go get` both fetching and installing are achieved:

```
$ go get github.com/progrium/go-extpoints
$ which go-extpoints 
/Users/pmoore/go/bin/go-extpoints
```
