### PR TITLE
Only interpret go files (e.g. not .*.go.swp files from vim)

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,7 +151,7 @@ func main() {
 
 	files, _ := ioutil.ReadDir(packagePath)
 	for _, file := range files {
-		if file.Name() != "extpoints.go" && !strings.HasSuffix(file.Name(), "_ext.go") {
+		if file.Name() != "extpoints.go" && !strings.HasSuffix(file.Name(), "_ext.go") && strings.HasSuffix(file.Name(), ".go") {
 			path := filepath.Join(packagePath, file.Name())
 			log.Printf("Processing file %s", path)
 			packageName, ifaces = processFile(path)


### PR DESCRIPTION
@progrium @jhford This is to avoid situations like:

```
extpoints: Could not parse file: engines/extpoints/.extpoints.go.swp:1:1: expected 'package', found 'IDENT' b0VIM (and 155 more errors)
```

Thanks!
